### PR TITLE
Fix `duckdb_arrow_scan` memory leak from `get_schema`.

### DIFF
--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -355,12 +355,6 @@ void EmptyStreamRelease(ArrowArrayStream *stream) {
 
 void FactoryGetSchema(ArrowArrayStream *stream, ArrowSchema &schema) {
 	stream->get_schema(stream, &schema);
-
-	// Need to nullify the root schema's release function here, because streams don't allow us to set the release
-	// function. For the schema's children, we nullify the release functions in `duckdb_arrow_scan`, so we don't need to
-	// handle them again here. We set this to nullptr and not EmptySchemaRelease to prevent ArrowSchemaWrapper's
-	// destructor from destroying the schema (it's the caller's responsibility).
-	schema.release = nullptr;
 }
 
 int GetSchema(struct ArrowArrayStream *stream, struct ArrowSchema *out) {
@@ -438,31 +432,7 @@ duckdb_state Ingest(duckdb_connection connection, const char *table_name, struct
 
 duckdb_state duckdb_arrow_scan(duckdb_connection connection, const char *table_name, duckdb_arrow_stream arrow) {
 	auto stream = reinterpret_cast<ArrowArrayStream *>(arrow);
-
-	// Backup release functions - we nullify children schema release functions because we don't want to release on
-	// behalf of the caller, downstream in our code. Note that Arrow releases target immediate children, but aren't
-	// recursive. So we only back up immediate children here and restore their functions.
-	ArrowSchema schema;
-	if (stream->get_schema(stream, &schema) == DuckDBError) {
-		return DuckDBError;
-	}
-
-	typedef void (*release_fn_t)(ArrowSchema *);
-	std::vector<release_fn_t> release_fns(duckdb::NumericCast<idx_t>(schema.n_children));
-	for (idx_t i = 0; i < duckdb::NumericCast<idx_t>(schema.n_children); i++) {
-		auto child = schema.children[i];
-		release_fns[i] = child->release;
-		child->release = arrow_array_stream_wrapper::EmptySchemaRelease;
-	}
-
-	auto ret = arrow_array_stream_wrapper::Ingest(connection, table_name, stream);
-
-	// Restore release functions.
-	for (idx_t i = 0; i < duckdb::NumericCast<idx_t>(schema.n_children); i++) {
-		schema.children[i]->release = release_fns[i];
-	}
-
-	return ret;
+	return arrow_array_stream_wrapper::Ingest(connection, table_name, stream);
 }
 
 duckdb_state duckdb_arrow_array_scan(duckdb_connection connection, const char *table_name,

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -432,6 +432,16 @@ duckdb_state Ingest(duckdb_connection connection, const char *table_name, struct
 
 duckdb_state duckdb_arrow_scan(duckdb_connection connection, const char *table_name, duckdb_arrow_stream arrow) {
 	auto stream = reinterpret_cast<ArrowArrayStream *>(arrow);
+
+	ArrowSchema schema;
+	if (stream->get_schema(stream, &schema) == DuckDBError) {
+		return DuckDBError;
+	}
+
+	if (schema.release) {
+		schema.release(&schema);
+	}
+
 	return arrow_array_stream_wrapper::Ingest(connection, table_name, stream);
 }
 


### PR DESCRIPTION
OK, this was a bit confusing and took an extra read or two. The basic flow is:

- Wrap stream `arrow_array_stream_wrapper::Ingest`
- Call table function with stream factory fns (`FactoryGetNext`, `FactoryGetSchema`) -> create view after
  - `ArrowScanBind` calls `FactoryGetSchema` to bind the schema to `ArrowScanFunctionData`
  - ...ClientContext::Execute

Every call to `get_schema` returns a copy [spec](https://arrow.apache.org/docs/format/CStreamInterface.html#c.ArrowArrayStream.get_schema):

> Mandatory. This callback allows the consumer to query the schema of the chunks of data in the stream. *The schema is the same for all data chunks.*

I was a little misled by this; they intend this to mean "semantically". If you look at lifetimes later on in the doc:

> The data returned by the get_schema and get_next callbacks must be released independently. Their lifetimes are not tied to that of the ArrowArrayStream.
