### PR TITLE
Default `ROW_GROUP_SIZE` 30_720 and make it configurable

### DIFF
--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -201,6 +201,8 @@ struct DBConfigOptions {
 	idx_t default_block_alloc_size = DEFAULT_BLOCK_ALLOC_SIZE;
 	//! The default block header size for new duckdb database files.
 	idx_t default_block_header_size = DUCKDB_BLOCK_HEADER_STORAGE_SIZE;
+	//! The default row group size for new duckdb database files (new as-in, they do not yet exist).
+	idx_t default_row_group_size = DEFAULT_ROW_GROUP_SIZE;
 	//!  Whether or not to abort if a serialization exception is thrown during WAL playback (when reading truncated WAL)
 	bool abort_on_wal_failure = false;
 	//! Paths that are explicitly allowed, even if enable_external_access is false

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -368,6 +368,17 @@ struct DefaultBlockSizeSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct DefaultRowGroupSizeSetting {
+	using RETURN_TYPE = idx_t;
+	static constexpr const char *Name = "default_row_group_size";
+	static constexpr const char *Description =
+	    "The default row group size for new duckdb database files (new as-in, they do not yet exist).";
+	static constexpr const char *InputType = "UBIGINT";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct DefaultCollationSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "default_collation";

--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -64,6 +64,7 @@ struct Storage {
 	//! Ensures that a user-provided block allocation size matches all requirements.
 	static void VerifyBlockAllocSize(const idx_t block_alloc_size);
 	static void VerifyBlockHeaderSize(const idx_t block_header_size);
+	static void VerifyRowGroupSize(const idx_t row_group_size);
 };
 
 //! The version number default, lower and upper bounds of the database storage format

--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -20,7 +20,7 @@ struct FileHandle;
 class QueryContext;
 
 //! The standard row group size
-#define DEFAULT_ROW_GROUP_SIZE 30720ULL //122880ULL
+#define DEFAULT_ROW_GROUP_SIZE 122880ULL //30720ULL
 //! The definition of an invalid block
 #define INVALID_BLOCK (-1)
 //! The maximum block id is 2^62

--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -20,7 +20,7 @@ struct FileHandle;
 class QueryContext;
 
 //! The standard row group size
-#define DEFAULT_ROW_GROUP_SIZE 122880ULL
+#define DEFAULT_ROW_GROUP_SIZE 30720ULL //122880ULL
 //! The definition of an invalid block
 #define INVALID_BLOCK (-1)
 //! The maximum block id is 2^62

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -89,6 +89,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING_CALLBACK(DebugVerifyVectorSetting),
     DUCKDB_SETTING_CALLBACK(DebugWindowModeSetting),
     DUCKDB_GLOBAL(DefaultBlockSizeSetting),
+    DUCKDB_GLOBAL(DefaultRowGroupSizeSetting),
     DUCKDB_SETTING_CALLBACK(DefaultCollationSetting),
     DUCKDB_SETTING_CALLBACK(DefaultNullOrderSetting),
     DUCKDB_SETTING_CALLBACK(DefaultOrderSetting),

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -428,6 +428,24 @@ Value DefaultBlockSizeSetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
+// Default Row Group Size
+//===----------------------------------------------------------------------===//
+void DefaultRowGroupSizeSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	auto row_group_size = input.GetValue<uint64_t>();
+	Storage::VerifyRowGroupSize(row_group_size);
+	config.options.default_row_group_size = row_group_size;
+}
+
+void DefaultRowGroupSizeSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	config.options.default_row_group_size = DBConfigOptions().default_row_group_size;
+}
+
+Value DefaultRowGroupSizeSetting::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::UBIGINT(config.options.default_row_group_size);
+}
+
+//===----------------------------------------------------------------------===//
 // Default Collation
 //===----------------------------------------------------------------------===//
 void DefaultCollationSetting::OnSet(SettingCallbackInfo &info, Value &input) {

--- a/src/storage/storage_info.cpp
+++ b/src/storage/storage_info.cpp
@@ -233,4 +233,21 @@ void Storage::VerifyBlockHeaderSize(const idx_t block_header_size) {
 	}
 }
 
+void Storage::VerifyRowGroupSize(const idx_t row_group_size) {
+	if (row_group_size == 0) {
+		throw InvalidInputException("Invalid row group size: %llu - row group size must be bigger than 0",
+		                            row_group_size);
+	}
+	if (row_group_size % STANDARD_VECTOR_SIZE != 0) {
+		throw InvalidInputException(
+		    "Invalid row group size: %llu - row group size must be divisible by the vector size (%llu)",
+		    row_group_size, STANDARD_VECTOR_SIZE);
+	}
+	if (row_group_size > MAX_ROW_GROUP_SIZE) {
+		throw InvalidInputException(
+		    "Invalid row group size: %llu - row group size must not exceed the maximum of %llu",
+		    row_group_size, MAX_ROW_GROUP_SIZE);
+	}
+}
+
 } // namespace duckdb

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -214,19 +214,14 @@ void SingleFileStorageManager::LoadDatabase(QueryContext context) {
 		options.encryption_options.user_key = std::move(storage_options.user_key);
 	}
 
-	idx_t row_group_size = DEFAULT_ROW_GROUP_SIZE;
+	idx_t row_group_size;
 	if (storage_options.row_group_size.IsValid()) {
 		row_group_size = storage_options.row_group_size.GetIndex();
-		if (row_group_size == 0) {
-			throw NotImplementedException("Invalid row group size: %llu - row group size must be bigger than 0",
-			                              row_group_size);
-		}
-		if (row_group_size % STANDARD_VECTOR_SIZE != 0) {
-			throw NotImplementedException(
-			    "Invalid row group size: %llu - row group size must be divisible by the vector size (%llu)",
-			    row_group_size, STANDARD_VECTOR_SIZE);
-		}
+	} else {
+		row_group_size = config.options.default_row_group_size;
 	}
+	Storage::VerifyRowGroupSize(row_group_size);
+	
 	// Check if the database file already exists.
 	// Note: a file can also exist if there was a ROLLBACK on a previous transaction creating that file.
 	if (!read_only && !fs.FileExists(path)) {


### PR DESCRIPTION
## 🗣 Description

1. Add support for `default_row_group_size` configuration param
2.  Change `DEFAULT_ROW_GROUP_SIZE`  122_880 -> 30_720


## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
