### PR TITLE
Apply Spice patches to DuckDB 1.5.2

### DIFF
--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -1,5 +1,8 @@
 #include "duckdb/execution/index/art/art.hpp"
 
+#include "duckdb/common/assert.hpp"
+#include "duckdb/common/helper.hpp"
+#include "duckdb/common/typedefs.hpp"
 #include "duckdb/common/types/conflict_manager.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
@@ -35,6 +38,17 @@ struct ARTIndexScanState : public IndexScanState {
 	Value values[2];
 	//! The expressions over the scan predicates.
 	ExpressionType expressions[2];
+	bool checked = false;
+	//! All scanned row IDs.
+	set<row_t> row_ids;
+};
+
+struct ARTIndexCompoundKeyScanState : public IndexScanState {
+	//! The predicates to scan.
+	//! A single predicate for each constituent key in a compound index.
+	vector<Value> values;
+	//! The expressions over the scan predicates.
+	vector<ExpressionType> expressions;
 	bool checked = false;
 	//! All scanned row IDs.
 	set<row_t> row_ids;
@@ -147,6 +161,34 @@ static unique_ptr<IndexScanState> InitializeScanTwoPredicates(const Value &low_v
 	result->values[1] = high_value;
 	result->expressions[1] = high_expression_type;
 	return std::move(result);
+}
+
+// Build compound scan state by building individual index scans and collecting their exprs/values
+unique_ptr<IndexScanState> ART::TryInitializeCompoundKeyScan(const vector<unique_ptr<Expression>> &index_exprs,
+                                                             vector<vector<unique_ptr<Expression>>> &exprs) {
+	auto compound_scan_state = make_uniq<ARTIndexCompoundKeyScanState>();
+
+	for (idx_t i = 0; i < index_exprs.size(); ++i) {
+		auto index_expr = &index_exprs[i];
+		auto filter_exprs = &exprs[i];
+
+		for (const auto &filter_expr : *filter_exprs) {
+			auto single_scan = ART::TryInitializeScan(**index_expr, *filter_expr);
+			if (!single_scan) {
+				return nullptr;
+			}
+
+			auto single_scan_concrete = single_scan->Cast<ARTIndexScanState>();
+			if (single_scan_concrete.expressions[0] != ExpressionType::COMPARE_EQUAL) {
+				return nullptr;
+			}
+
+			compound_scan_state->values.push_back(single_scan_concrete.values[0]);
+			compound_scan_state->expressions.push_back(single_scan_concrete.expressions[0]);
+		}
+	}
+
+	return compound_scan_state;
 }
 
 unique_ptr<IndexScanState> ART::TryInitializeScan(const Expression &expr, const Expression &filter_expr) {
@@ -758,6 +800,30 @@ bool ART::SearchCloseRange(ARTKey &lower_bound, ARTKey &upper_bound, bool left_e
 	// Continue the scan until we reach the upper bound.
 	RowIdSetOutput output(row_ids, max_count);
 	return it.Scan(upper_bound, output, right_equal) == ARTScanResult::COMPLETED;
+}
+
+bool ART::CompoundKeyScan(IndexScanState &state, const idx_t max_count, set<row_t> &row_ids) {
+	auto &scan_state = state.Cast<ARTIndexCompoundKeyScanState>();
+
+	if (scan_state.values.size() != types.size()) {
+		return false;
+	}
+
+	for (idx_t i = 0; i < scan_state.values.size(); ++i) {
+		D_ASSERT(scan_state.values[i].type().InternalType() == types[i]);
+	}
+
+	ArenaAllocator arena_allocator(Allocator::Get(db));
+
+	// Make a compound key from the collected state values
+	auto compound_key = ARTKey::CreateKey(arena_allocator, scan_state.values[0], storage_version);
+	for (idx_t i = 1; i < scan_state.values.size(); ++i) {
+		auto part_key = ARTKey::CreateKey(arena_allocator, scan_state.values[i], storage_version);
+		compound_key.Concat(arena_allocator, part_key);
+	}
+
+	lock_guard<mutex> l(lock);
+	return SearchEqual(compound_key, max_count, row_ids);
 }
 
 bool ART::Scan(IndexScanState &state, const idx_t max_count, set<row_t> &row_ids) {

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -188,7 +188,7 @@ unique_ptr<IndexScanState> ART::TryInitializeCompoundKeyScan(const vector<unique
 		}
 	}
 
-	return compound_scan_state;
+	return std::move(compound_scan_state);
 }
 
 unique_ptr<IndexScanState> ART::TryInitializeScan(const Expression &expr, const Expression &filter_expr) {

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -583,7 +583,7 @@ bool TryScanIndex(ART &art, IndexEntry &entry, const ColumnList &column_list, Ta
 	for (idx_t i = 0; i < indexed_columns.size(); ++i) {
 		for (idx_t j = 0; j < input.column_ids.size(); ++j) {
 			if (indexed_columns[i] == input.column_ids[j]) {
-				rewrite_index_exprs = i != j;
+				rewrite_index_exprs = rewrite_index_exprs || i != j;
 				index_column_to_input_pos.at(i) = j;
 				break;
 			}

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -31,6 +31,9 @@
 #include "duckdb/common/types/value_map.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/transaction/duck_transaction_manager.hpp"
+#include <limits>
+#include <list>
+#include <utility>
 
 namespace duckdb {
 
@@ -558,70 +561,127 @@ vector<unique_ptr<Expression>> ExtractFilterExpressions(const ColumnDefinition &
 
 bool TryScanIndex(ART &art, IndexEntry &entry, const ColumnList &column_list, TableFunctionInitInput &input,
                   TableFilterSet &filter_set, idx_t max_count, set<row_t> &row_ids) {
-	// FIXME: No support for index scans on compound ARTs.
-	// See note above on multi-filter support.
-	if (art.unbound_expressions.size() > 1) {
-		return false;
+	vector<unique_ptr<Expression>> index_exprs;
+	for (const auto &expr : art.unbound_expressions) {
+		index_exprs.push_back(expr->Copy());
 	}
 
-	auto index_expr = art.unbound_expressions[0]->Copy();
+	// If this is a view, the column IDs are (may be?) relative to the view projection
 	auto &indexed_columns = art.GetColumnIds();
 
-	// NOTE: We do not push down multi-column filters, e.g., 42 = a + b.
-	if (indexed_columns.size() != 1) {
+	// Allow composite ART scans
+	if (indexed_columns.size() != index_exprs.size()) {
 		return false;
 	}
 
 	// Resolve bound column references in the index_expr against the current input projection
-	column_t updated_index_column;
-	bool found_index_column_in_input = false;
+	bool rewrite_index_exprs = false;
+	vector<column_t> index_column_to_input_pos;
+	index_column_to_input_pos.resize(indexed_columns.size(), std::numeric_limits<idx_t>::max());
 
-	// Find the indexed column amongst the input columns
-	for (idx_t i = 0; i < input.column_ids.size(); ++i) {
-		if (input.column_ids[i] == indexed_columns[0]) {
-			updated_index_column = i;
-			found_index_column_in_input = true;
-			break;
+	// Associate indexed columns to input columns
+	for (idx_t i = 0; i < indexed_columns.size(); ++i) {
+		for (idx_t j = 0; j < input.column_ids.size(); ++j) {
+			if (indexed_columns[i] == input.column_ids[j]) {
+				rewrite_index_exprs = i != j;
+				index_column_to_input_pos.at(i) = j;
+				break;
+			}
 		}
 	}
 
-	// If found, update the bound column ref within index_expr
-	if (found_index_column_in_input) {
-		ExpressionIterator::EnumerateExpression(index_expr, [&](Expression &expr) {
-			if (expr.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
-				return;
-			}
+	// Make sure that all indexed_columns were bound, or bail out
+	for (auto col : index_column_to_input_pos) {
+		if (col == std::numeric_limits<idx_t>::max()) {
+			return false;
+		}
+	}
 
-			auto &bound_column_ref_expr = expr.Cast<BoundColumnRefExpression>();
+	// Allow scan only if index expressions reference ONE column each, and that column
+	// is associated with an indexed_column
+	// NOTE: We do not push down multi-column filters, e.g., 42 = a + b.
+	for (idx_t i = 0; i < index_exprs.size(); ++i) {
+		unordered_set<column_t> referenced_columns;
+		auto expr = &index_exprs[i];
 
-			// If the bound column references the index column, use updated_index_column
-			if (bound_column_ref_expr.binding.column_index == indexed_columns[0]) {
-				bound_column_ref_expr.binding.column_index = updated_index_column;
+		// Walk the expr in case of nesting (e.g. function)
+		ExpressionIterator::EnumerateExpression(*expr, [&](Expression &child_expr) {
+			if (child_expr.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+				auto &col_ref = child_expr.Cast<BoundColumnRefExpression>();
+				referenced_columns.insert(col_ref.binding.column_index);
 			}
 		});
-	}
 
-	// Get ART column.
-	auto &col = column_list.GetColumn(LogicalIndex(indexed_columns[0]));
+		if (referenced_columns.size() != 1) {
+			return false;
+		}
 
-	// The indexes of the filters match input.column_indexes, which are: i -> column_index.
-	// Try to find a filter on the ART column.
-	optional_idx storage_index;
-	for (idx_t i = 0; i < input.column_indexes.size(); i++) {
-		if (input.column_indexes[i].ToLogical() == col.Logical()) {
-			storage_index = i;
-			break;
+		// Make sure the column reference can be looked up
+		auto ref_col_idx = *referenced_columns.begin();
+		if (ref_col_idx >= index_column_to_input_pos.size() || ref_col_idx >= input.column_ids.size()) {
+			return false;
+		}
+
+		// The column for this position matches the indexed_column ID for this position directly
+		auto direct_match = input.column_ids[ref_col_idx] == indexed_columns[i];
+
+		// We should know if there is a different mapping for this reference.
+		// If there is not, it won't match, so it is not worth trying.
+		if (!direct_match && !rewrite_index_exprs) {
+			return false;
+		}
+
+		auto remapped_cid_position = index_column_to_input_pos[ref_col_idx];
+		auto remapped_match = remapped_cid_position < input.column_ids.size() &&
+		                      input.column_ids[remapped_cid_position] == indexed_columns[i];
+
+		if (!(direct_match || remapped_match)) {
+			return false;
 		}
 	}
 
-	// No filter matches the ART column.
-	if (!storage_index.IsValid()) {
-		return false;
+	// If the position of the indexed_columns differs from the order of the input, remap the index expressions
+	if (rewrite_index_exprs) {
+		for (auto &index_expr : index_exprs) {
+			ExpressionIterator::EnumerateExpression(index_expr, [&](Expression &expr) {
+				if (expr.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
+					return;
+				}
+
+				auto &bound_column_ref_expr = expr.Cast<BoundColumnRefExpression>();
+
+				// If the bound column references an indexed column, update it
+				for (idx_t i = 0; i < indexed_columns.size(); ++i) {
+					auto remapped_index = index_column_to_input_pos[bound_column_ref_expr.binding.column_index];
+					if (input.column_ids[remapped_index] == indexed_columns[i]) {
+						bound_column_ref_expr.binding.column_index = index_column_to_input_pos[i];
+						break;
+					}
+				}
+			});
+		}
 	}
 
-	// Try to find a matching filter for the column.
-	auto filter = filter_set.filters.find(storage_index.GetIndex());
-	if (filter == filter_set.filters.end()) {
+	// The indexes of the filters match input.column_indexes, which are: i -> column_index.
+	// Reuse the index <-> projection mappings from index expr rebinding (which are canonical even if not rewriting)
+	vector<vector<unique_ptr<Expression>>> index_filters;
+
+	for (idx_t i = 0; i < index_column_to_input_pos.size(); ++i) {
+		auto column_def = &column_list.GetColumn(LogicalIndex(indexed_columns[i]));
+		auto maybe_filter = filter_set.filters.find(index_column_to_input_pos[i]);
+		if (maybe_filter != filter_set.filters.end()) {
+			auto filter = &maybe_filter->second;
+			auto filter_expressions = ExtractFilterExpressions(*column_def, *filter, index_column_to_input_pos[i]);
+
+			index_filters.push_back(std::move(filter_expressions));
+		}
+	}
+
+	// Index filters must:
+	// - Match ART column count 1:1
+	// - Match filter expression set 1:1 (there may be filters on non-indexed columns, bail out if so)
+	if (index_filters.size() != indexed_columns.size() || filter_set.filters.size() != index_filters.size() ||
+	    index_filters.empty()) {
 		return false;
 	}
 
@@ -641,22 +701,40 @@ bool TryScanIndex(ART &art, IndexEntry &entry, const ColumnList &column_list, Ta
 		arts_to_scan.push_back(entry.added_data_during_checkpoint->Cast<ART>());
 	}
 
-	auto expressions = ExtractFilterExpressions(col, filter->second, storage_index.GetIndex());
-	for (const auto &filter_expr : expressions) {
+	// Do a compound scan if we have filter exprs bound for several columns
+	if (index_filters.size() > 1) {
 		for (auto &art_ref : arts_to_scan) {
 			auto &art_to_scan = art_ref.get();
-			auto scan_state = art_to_scan.TryInitializeScan(*index_expr, *filter_expr);
+			auto scan_state = art_to_scan.TryInitializeCompoundKeyScan(index_exprs, index_filters);
 			if (!scan_state) {
 				return false;
 			}
 
-			// Check if we can use an index scan, and already retrieve the matching row ids.
-			if (!art_to_scan.Scan(*scan_state, max_count, row_ids)) {
+			if (!art_to_scan.CompoundKeyScan(*scan_state, max_count, row_ids)) {
 				row_ids.clear();
 				return false;
 			}
 		}
 	}
+	// Original single column index scan
+	else {
+		for (const auto &filter_expr : index_filters[0]) {
+			for (auto &art_ref : arts_to_scan) {
+				auto &art_to_scan = art_ref.get();
+				auto scan_state = art_to_scan.TryInitializeScan(*index_exprs[0], *filter_expr);
+				if (!scan_state) {
+					return false;
+				}
+
+				// Check if we can use an index scan, and already retrieve the matching row ids.
+				if (!art_to_scan.Scan(*scan_state, max_count, row_ids)) {
+					row_ids.clear();
+					return false;
+				}
+			}
+		}
+	}
+
 	return true;
 }
 
@@ -679,9 +757,9 @@ unique_ptr<GlobalTableFunctionState> TableScanInitGlobal(ClientContext &context,
 	//		1.2. Find + scan one ART for b = 24.
 	//		1.3. Return the intersecting row IDs.
 	// 2. (Reorder and) scan a single ART with a compound key of (a, b).
-	if (filter_set.filters.size() != 1) {
-		return DuckTableScanInitGlobal(context, input, storage, bind_data);
-	}
+	// if (filter_set.filters.size() != 1) {
+	// 	return DuckTableScanInitGlobal(context, input, storage, bind_data);
+	// }
 
 	auto &info = storage.GetDataTableInfo();
 	auto &indexes = info->GetIndexes();

--- a/src/include/duckdb/execution/index/art/art.hpp
+++ b/src/include/duckdb/execution/index/art/art.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/execution/index/bound_index.hpp"
 #include "duckdb/execution/index/art/node.hpp"
 #include "duckdb/common/array.hpp"
+#include "duckdb/planner/expression.hpp"
 
 namespace duckdb {
 
@@ -24,6 +25,7 @@ class ARTKeySection;
 class FixedSizeAllocator;
 
 struct ARTIndexScanState;
+struct ARTIndexCompoundKeyScanState;
 
 struct DeleteIndexInfo {
 	DeleteIndexInfo() : delete_indexes(nullptr) {
@@ -75,6 +77,11 @@ public:
 	//! Try to initialize a scan on the ART with the given expression and filter.
 	unique_ptr<IndexScanState> TryInitializeScan(const Expression &expr, const Expression &filter_expr);
 	unique_ptr<IndexScanState> InitializeFullScan();
+
+	//! Try to initialize a compound key scan on the ART, using the given index expr -> filter expr mappings.
+	//! Supports equality comparisons only.
+	unique_ptr<IndexScanState> TryInitializeCompoundKeyScan(const vector<unique_ptr<Expression>> &index_exprs,
+	                                                        vector<vector<unique_ptr<Expression>>> &exprs);
 	//! Perform a lookup on the ART, fetching up to max_count row IDs.
 	//! If all row IDs were fetched, it return true, else false.
 	bool Scan(IndexScanState &state, idx_t max_count, set<row_t> &row_ids);
@@ -92,6 +99,10 @@ public:
 	ErrorData InsertMerge(IndexLock &state, BoundIndex &source_index, IndexAppendMode append_mode);
 	//! Obtains a lock and calls InsertMerge while holding that lock.
 	ErrorData InsertMerge(BoundIndex &source_index, IndexAppendMode append_mode);
+
+	//! Like `ART::Scan`, but uses `ARTIndexCompoundKeyScanState` to concatenate multiple
+	//! values for equality comparisons only.
+	bool CompoundKeyScan(IndexScanState &state, idx_t max_count, set<row_t> &row_ids);
 
 	//! Appends data to the locked index.
 	ErrorData Append(IndexLock &l, DataChunk &chunk, Vector &row_ids) override;

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -357,12 +357,6 @@ void EmptyStreamRelease(ArrowArrayStream *stream) {
 
 void FactoryGetSchema(ArrowArrayStream *stream, ArrowSchema &schema) {
 	stream->get_schema(stream, &schema);
-
-	// Need to nullify the root schema's release function here, because streams don't allow us to set the release
-	// function. For the schema's children, we nullify the release functions in `duckdb_arrow_scan`, so we don't need to
-	// handle them again here. We set this to nullptr and not EmptySchemaRelease to prevent ArrowSchemaWrapper's
-	// destructor from destroying the schema (it's the caller's responsibility).
-	schema.release = nullptr;
 }
 
 int GetSchema(struct ArrowArrayStream *stream, struct ArrowSchema *out) {
@@ -441,30 +435,16 @@ duckdb_state Ingest(duckdb_connection connection, const char *table_name, struct
 duckdb_state duckdb_arrow_scan(duckdb_connection connection, const char *table_name, duckdb_arrow_stream arrow) {
 	auto stream = reinterpret_cast<ArrowArrayStream *>(arrow);
 
-	// Backup release functions - we nullify children schema release functions because we don't want to release on
-	// behalf of the caller, downstream in our code. Note that Arrow releases target immediate children, but aren't
-	// recursive. So we only back up immediate children here and restore their functions.
 	ArrowSchema schema;
 	if (stream->get_schema(stream, &schema) == DuckDBError) {
 		return DuckDBError;
 	}
 
-	typedef void (*release_fn_t)(ArrowSchema *);
-	std::vector<release_fn_t> release_fns(duckdb::NumericCast<idx_t>(schema.n_children));
-	for (idx_t i = 0; i < duckdb::NumericCast<idx_t>(schema.n_children); i++) {
-		auto child = schema.children[i];
-		release_fns[i] = child->release;
-		child->release = arrow_array_stream_wrapper::EmptySchemaRelease;
+	if (schema.release) {
+		schema.release(&schema);
 	}
 
-	auto ret = arrow_array_stream_wrapper::Ingest(connection, table_name, stream);
-
-	// Restore release functions.
-	for (idx_t i = 0; i < duckdb::NumericCast<idx_t>(schema.n_children); i++) {
-		schema.children[i]->release = release_fns[i];
-	}
-
-	return ret;
+	return arrow_array_stream_wrapper::Ingest(connection, table_name, stream);
 }
 
 duckdb_state duckdb_arrow_array_scan(duckdb_connection connection, const char *table_name,

--- a/test/sql/index/art/issues/test_art_rewrite_index_exprs.test
+++ b/test/sql/index/art/issues/test_art_rewrite_index_exprs.test
@@ -1,0 +1,30 @@
+# name: test/sql/index/art/issues/test_art_rewrite_index_exprs.test
+# description: Test index scan through views where the last index column has i==j position
+# group: [issues]
+
+# Bug: rewrite_index_exprs was assigned (not OR'd) per match. If the last index
+# column sits at position i==j the flag resets to false, skipping column rebinding.
+
+statement ok
+CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER);
+
+statement ok
+INSERT INTO t VALUES (1, 2, 3), (4, 5, 6), (7, 8, 9);
+
+statement ok
+CREATE INDEX idx ON t(a, b, c);
+
+# View swaps a and b but keeps c at position 2 (i==j for last index col)
+statement ok
+CREATE VIEW v AS SELECT b, a, c FROM t;
+
+# Must use Index Scan, not Sequential Scan
+query II
+explain analyze select * from v where a = 1 AND b = 2 AND c = 3;
+----
+analyzed_plan	<REGEX>:.*Index Scan.*
+
+query III
+select b, a, c from v where a = 1 AND b = 2 AND c = 3;
+----
+2	1	3

--- a/test/sql/index/art/issues/test_art_view_col_binding.test
+++ b/test/sql/index/art/issues/test_art_view_col_binding.test
@@ -46,3 +46,26 @@ select z, y, x from test_view where upper(x) = '526';
 
 statement ok
 drop index test_upper_x;
+
+statement ok
+create or replace table other_test_table (
+    name VARCHAR NOT NULL,
+    id BIGINT NOT NULL,
+    age INTEGER,
+    status VARCHAR NOT NULL
+);
+
+statement ok
+INSERT INTO other_test_table VALUES ('alice', 1, 30, 'active'), ('bob', 2, 25, 'inactive');
+
+# test simple permutation of initial table projection
+statement ok
+CREATE INDEX index_id_other_test_table ON other_test_table (id);
+
+statement ok
+CREATE OR REPLACE VIEW ott_view AS SELECT * FROM other_test_table;
+
+query II
+explain analyze select * from ott_view where id = 1;
+----
+analyzed_plan	<REGEX>:.*Index Scan.*

--- a/test/sql/index/art/scan/test_art_composite_key_scan.test
+++ b/test/sql/index/art/scan/test_art_composite_key_scan.test
@@ -1,0 +1,25 @@
+# name: test/sql/index/art/scan/test_art_composite_key_scan.test
+# description: Test Index Scan push down against views with reordered projections (issue #17290)
+# group: [scan]
+
+statement ok
+create or replace table test as (
+    select
+        cast(unnest(range(1000)) as varchar) as x,
+        cast(unnest(range(2000,3000)) as varchar) as y,
+        cast(unnest(range(3000,4000)) as varchar) as z
+);
+
+# test simple permutation of initial table projection
+statement ok
+create index test_composite_key on test(x, y, z);
+
+query II
+explain analyze select * from test where x = '525' and y = '2525' and z = '3525';
+----
+analyzed_plan	<REGEX>:.*Index Scan.*
+
+query III
+select * from test where x = '525' and y = '2525' and z = '3525';
+----
+525	2525	3525


### PR DESCRIPTION
## 🗣 Description

Build + the following tests were run to verify

```
 1. Composite key scan (commit 1) - verifies Index Scan is used + correct results
./build/debug/test/unittest "test/sql/index/art/scan/test_art_composite_key_scan.test"

# 2. View column binding with index (commit 1) - verifies index scan works through views
./build/debug/test/unittest "test/sql/index/art/issues/test_art_view_col_binding.test"

# 3. Arrow C API tests (commit 3) - verifies arrow scan correctness
./build/debug/test/unittest "[arrow][capi]"

# 4. All ART scan + issues tests (regression) - no regressions in index scans
./build/debug/test/unittest "test/sql/index/art/scan/*,test/sql/index/art/issues/*"
```

```
⚡ ./build/debug/test/unittest "test/sql/index/art/scan/test_art_composite_key_scan.test"
Filters: test/sql/index/art/scan/test_art_composite_key_scan.test
[1/1] (100%): test/sql/index/art/scan/test_art_composite_key_scan.test                                                      
===============================================================================
All tests passed (7 assertions in 1 test case)

⚡ ./build/debug/test/unittest "test/sql/index/art/issues/test_art_view_col_binding.test"
Filters: test/sql/index/art/issues/test_art_view_col_binding.test
[1/1] (100%): test/sql/index/art/issues/test_art_view_col_binding.test                                                      
===============================================================================
All tests passed (22 assertions in 1 test case)

⚡ ./build/debug/test/unittest "[arrow][capi]"
Filters: [arrow][capi]
[3/3] (100%): Test streaming arrow results in C API                                                                         
===============================================================================
All tests passed (103693 assertions in 3 test cases)

⚡ ./build/debug/test/unittest "test/sql/index/art/scan/*,test/sql/index/art/issues/*"
Filters: test/sql/index/art/scan/*,test/sql/index/art/issues/*
[25/25] (100%): test/sql/index/art/issues/test_art_fuzzer_persisted.test                                                    
============================================================================
All tests passed (1 skipped test, 363 assertions in 24 test cases)

Skipped tests for the following reasons:
require tpch: 1
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
